### PR TITLE
Expandable breadcrumbs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,8 @@ jobs:
         run: npm ci
       - name: Build package
         run: ./tasks/build-package.sh
+      - name: Test package
+        run: node tasks/test-package.js || exit 1
       - name: Check npm credentials
         run: npm whoami
       - name: Publish to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improvements to high contrast themes
 - Full-height layouts need a `#main-content[role="main"]` rather than just a `#main[role="main"]`
 - Added `role="button"` to all TNA buttons
+- Allow collapsed breadcrumbs to be expanded on mobile devices
 
 ### Deprecated
 ### Removed

--- a/src/nationalarchives/all.mjs
+++ b/src/nationalarchives/all.mjs
@@ -1,3 +1,4 @@
+import { Breadcrumbs } from "./components/breadcrumbs/breadcrumbs.mjs";
 import { Card } from "./components/card/card.mjs";
 import { Header } from "./components/header/header.mjs";
 import { Picture } from "./components/picture/picture.mjs";
@@ -45,15 +46,20 @@ const initAll = (options) => {
   const $scope =
     options.scope instanceof HTMLElement ? options.scope : document;
 
-  const $header = $scope.querySelector('[data-module="tna-header"]');
-  if ($header) {
-    new Header($header).init();
+  const $breadcrumbs = $scope.querySelector('[data-module="tna-breadcrumbs"]');
+  if ($breadcrumbs) {
+    new Breadcrumbs($breadcrumbs).init();
   }
 
   const $cards = $scope.querySelectorAll('[data-module="tna-card"]');
   $cards.forEach(($card) => {
     new Card($card).init();
   });
+
+  const $header = $scope.querySelector('[data-module="tna-header"]');
+  if ($header) {
+    new Header($header).init();
+  }
 
   const $pictures = $scope.querySelectorAll('[data-module="tna-picture"]');
   $pictures.forEach(($picture) => {
@@ -73,4 +79,4 @@ const initAll = (options) => {
   });
 };
 
-export { initAll, Header, SensitiveImage, Tabs };
+export { initAll, Breadcrumbs, Card, Header, Picture, SensitiveImage, Tabs };

--- a/src/nationalarchives/components/breadcrumbs/_index.scss
+++ b/src/nationalarchives/components/breadcrumbs/_index.scss
@@ -5,6 +5,14 @@
   padding-top: 1rem;
   padding-bottom: 1rem;
 
+  &__wrapper {
+    .tna-template--clicked & {
+      &:focus {
+        outline: none !important;
+      }
+    }
+  }
+
   &__list {
     margin: 0;
     padding: 0;
@@ -26,6 +34,10 @@
 
         content: "\203A";
       }
+    }
+
+    &--expandable {
+      display: none;
     }
   }
 
@@ -61,6 +73,30 @@
     }
   }
 
+  button#{&}__link {
+    margin: 0;
+    padding: 0;
+
+    font-size: inherit;
+    line-height: inherit;
+
+    background-color: transparent;
+
+    border: none;
+
+    appearance: none;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-thickness: 3px;
+    }
+  }
+
+  &__link-expandable-label {
+    font-size: 0;
+  }
+
   @include media.on-mobile {
     // &__item {
     //   &,
@@ -85,8 +121,17 @@
     //   }
     // }
 
-    &__item:not(:first-child, :last-child) {
+    &__list--collapse-on-mobile
+      #{&}__item:not(
+        :first-child,
+        .tna-breadcrumbs__item--expandable,
+        :last-child
+      ) {
       display: none;
+    }
+
+    &__list--collapse-on-mobile #{&}__item--expandable {
+      display: inline-block;
     }
   }
 }

--- a/src/nationalarchives/components/breadcrumbs/breadcrumbs.mjs
+++ b/src/nationalarchives/components/breadcrumbs/breadcrumbs.mjs
@@ -1,0 +1,63 @@
+import uuidv4 from "../../lib/uuid.mjs";
+
+export class Breadcrumbs {
+  constructor($module) {
+    this.$module = $module;
+    this.$breadcrumbsListWrapper =
+      $module && $module.querySelector(".tna-breadcrumbs__wrapper");
+    this.$breadcrumbsList =
+      $module &&
+      this.$breadcrumbsListWrapper &&
+      $module.querySelector(".tna-breadcrumbs__list");
+    this.$breadcrumbs =
+      $module &&
+      this.$breadcrumbsListWrapper &&
+      this.$breadcrumbsList &&
+      $module.querySelectorAll(".tna-breadcrumbs__item");
+  }
+
+  init() {
+    if (
+      !this.$module ||
+      !this.$breadcrumbsListWrapper ||
+      !this.$breadcrumbsList ||
+      !this.$breadcrumbs
+    ) {
+      return;
+    }
+
+    if (this.$breadcrumbs.length > 2) {
+      const uniqueId = `tna-breadcrumbs-${uuidv4()}`;
+
+      const $expandable = document.createElement("li");
+      $expandable.classList.add(
+        "tna-breadcrumbs__item",
+        "tna-breadcrumbs__item--expandable",
+      );
+
+      const $expandButton = document.createElement("button");
+      $expandButton.classList.add("tna-breadcrumbs__link");
+      $expandButton.innerHTML =
+        "<span class='tna-breadcrumbs__link-expandable-label'>Expand breadcrumbs</span>&hellip;";
+      $expandButton.setAttribute("aria-expanded", "false");
+      $expandButton.setAttribute("aria-controls", uniqueId);
+      $expandButton.addEventListener("click", () => {
+        this.$breadcrumbsList.classList.remove(
+          "tna-breadcrumbs__list--collapse-on-mobile",
+        );
+        $expandable.remove();
+        this.$breadcrumbsListWrapper.setAttribute("tabindex", "0");
+        this.$breadcrumbsListWrapper.focus();
+        this.$breadcrumbsListWrapper.setAttribute("tabindex", "-1");
+      });
+
+      $expandable.appendChild($expandButton);
+
+      this.$breadcrumbsList.setAttribute("id", uniqueId);
+      this.$breadcrumbsList.insertBefore(
+        $expandable,
+        this.$breadcrumbs[this.$breadcrumbs.length - 2].nextSibling,
+      );
+    }
+  }
+}

--- a/src/nationalarchives/components/breadcrumbs/fixtures.json
+++ b/src/nationalarchives/components/breadcrumbs/fixtures.json
@@ -19,7 +19,7 @@
           }
         ]
       },
-      "html": "<div class=\"tna-breadcrumbs tna-container \"><nav class=\"tna-column tna-column--full\" aria-label=\"Breadcrumb\"><ol class=\"tna-breadcrumbs__list\"><li class=\"tna-breadcrumbs__item\"><a href=\"#/alpha\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Alpha</a></li><li class=\"tna-breadcrumbs__item\"><a href=\"#/beta\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Beta</a></li><li class=\"tna-breadcrumbs__item\"><a href=\"#/gamma\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Gamma</a></li></ol></nav></div>",
+      "html": "<div class=\"tna-breadcrumbs tna-container \" data-module=\"tna-breadcrumbs\"><nav class=\"tna-breadcrumbs__wrapper tna-column tna-column--full\" aria-label=\"Breadcrumb\"><ol class=\"tna-breadcrumbs__list tna-breadcrumbs__list--collapse-on-mobile\"><li class=\"tna-breadcrumbs__item\"><a href=\"#/alpha\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Alpha</a></li><li class=\"tna-breadcrumbs__item\"><a href=\"#/beta\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Beta</a></li><li class=\"tna-breadcrumbs__item\"><a href=\"#/gamma\" class=\"tna-breadcrumbs__link\" data-prefix=\"Back to\">Gamma</a></li></ol></nav></div>",
       "hidden": false
     }
   ]

--- a/src/nationalarchives/components/breadcrumbs/template.njk
+++ b/src/nationalarchives/components/breadcrumbs/template.njk
@@ -1,7 +1,7 @@
 {%- set containerClasses = [params.classes] if params.classes else [] -%}
-<div class="tna-breadcrumbs tna-container {{ containerClasses | join(' ') }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  <nav class="tna-column tna-column--full" aria-label="Breadcrumb">
-    <ol class="tna-breadcrumbs__list">
+<div class="tna-breadcrumbs tna-container {{ containerClasses | join(' ') }}" data-module="tna-breadcrumbs" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <nav class="tna-breadcrumbs__wrapper tna-column tna-column--full" aria-label="Breadcrumb">
+    <ol class="tna-breadcrumbs__list tna-breadcrumbs__list--collapse-on-mobile">
     {%- for item in params.items -%}
       <li class="tna-breadcrumbs__item">
         <a href="{{ item.href }}" class="tna-breadcrumbs__link" data-prefix="{{ params.prefix if params.prefix else 'Back to' }}" {%- if item.title %} title="{{ item.title }}"{% endif %}>

--- a/tasks/test-package.js
+++ b/tasks/test-package.js
@@ -42,7 +42,7 @@ const checkExists = [
   "nationalarchives/assets/images/tna-horizontal-logo.svg",
   "nationalarchives/assets/images/tna-square-logo.svg",
   // Components
-  ...componentFiles("breadcrumbs", true),
+  ...componentFiles("breadcrumbs"),
   ...componentFiles("button", true),
   ...componentFiles("card"),
   ...componentFiles("filters", true),


### PR DESCRIPTION
When JavaScript is available, collapsed breadcrumbs on a mobile device will be given an extra button that allows the user to expand the buttons

Normal (no JavaScript)
<img width="612" alt="Screenshot 2023-08-15 at 18 50 16" src="https://github.com/nationalarchives/tna-frontend/assets/2356642/21df7f8b-ba19-4eda-9f2f-ca445dd4e93c">

JavaScript-added expand button
<img width="612" alt="Screenshot 2023-08-15 at 18 50 20" src="https://github.com/nationalarchives/tna-frontend/assets/2356642/b5932d82-3612-4dd5-af21-97cbc3890349">

Expanded mobile breadcrumbs
<img width="612" alt="Screenshot 2023-08-15 at 18 50 22" src="https://github.com/nationalarchives/tna-frontend/assets/2356642/e994810e-eaaf-4896-b897-380ee34be38a">