### PR TITLE
Styles and stories for the event card

### DIFF
--- a/src/nationalarchives/components/card/card.scss
+++ b/src/nationalarchives/components/card/card.scss
@@ -16,6 +16,10 @@
 
   &__heading {
     order: 2;
+
+    &--has-highlight {
+      max-width: calc(100% - 5.125rem);
+    }
   }
 
   &__heading-link {
@@ -84,6 +88,28 @@
     }
   }
 
+  &__tags {
+    display: flex;
+    align-self: flex-start;
+    list-style-type: none;
+    flex-basis: 50%;
+    border: 2px solid colour.brand-colour("pastel-pink");
+    padding: 0;
+    order: 2;
+  }
+
+  &__tag {
+    @include typography.relative-font-size(14);
+    @include typography.detail-font;
+    text-transform: uppercase;
+    padding: 0 0.4rem;
+
+    &--event-type {
+      @include colour.fixed;
+      background-color: colour.brand-colour("pastel-pink");
+    }
+  }
+
   &__actions {
     margin-top: 2rem;
 
@@ -96,6 +122,35 @@
     .fa-solid,
     .fa-brands {
       margin-right: 0.5rem;
+    }
+  }
+
+  &__highlight {
+    @include typography.relative-font-size(14);
+    @include colour.fixed;
+    z-index: 1;
+    border-radius: 50%;
+    aspect-ratio: 1 / 1;
+    align-self: flex-end;
+    position: absolute;
+    right: 1.14rem;
+    top: 1.14rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+
+    @include media.on-larger-than-mobile {
+      right: 0;
+      top: auto;
+    }
+
+    &--yellow {
+      background-color: colour.brand-colour("pastel-orange");
+    }
+
+    &--blue {
+      background-color: colour.brand-colour("pastel-blue");
     }
   }
 
@@ -156,6 +211,18 @@
     }
   }
 
+  &--horizontal-thirds {
+    @include media.on-larger-than-mobile {
+      .tna-card__inner {
+        margin-left: 33.33%;
+      }
+
+      .tna-card__image-container {
+        inset: 0 66.66% 0 0;
+      }
+    }
+  }
+
   &--horizontal#{&}--contrast,
   &--horizontal#{&}--accent {
     @include media.on-mobile {
@@ -187,6 +254,53 @@
       .tna-card__actions {
         margin-right: 1rem;
         margin-left: 1rem;
+      }
+    }
+  }
+
+  &--event {
+    .tna-card__inner {
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+
+      @include media.on-larger-than-mobile {
+        padding: 1rem 2rem 1rem 2.5rem;
+      }
+    }
+
+    .tna-card__image-container {
+      margin-left: -1.5rem;
+      margin-right: -1.5rem;
+
+      @include media.on-larger-than-mobile {
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+
+    .tna-card__heading {
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+
+      @include media.on-larger-than-mobile {
+        @include typography.relative-font-size(30);
+      }
+    }
+
+    .tna-card__heading-link {
+      @include colour.colour-font("font-dark");
+    }
+
+    .tna-card__body {
+      @include typography.relative-font-size(16);
+      line-height: 1.5;
+    }
+
+    .tna-card__meta {
+      .fa-solid {
+        @include colour.fixed;
+        @include colour.colour-font("keyline");
+        @include typography.relative-font-size(24);
       }
     }
   }

--- a/src/nationalarchives/components/card/card.stories.js
+++ b/src/nationalarchives/components/card/card.stories.js
@@ -22,6 +22,26 @@ const argTypes = {
   htmlElement: { control: "text" },
   classes: { control: "text" },
   attributes: { control: "object" },
+  event: { control: "boolean" },
+  eventType: {
+    control: "inline-radio",
+    options: ["Exhibition", "Display", "Talk", "Tour", "Event"],
+  },
+  accessDescriptor: {
+    control: "inline-radio",
+    options: [
+      "Speech to text",
+      "British Sign Language",
+      "Accessible",
+      "Autism-friendly",
+      "",
+    ],
+  },
+  highlight: {
+    control: "inline-radio",
+    options: ["Sold out", "Opening soon", "Last chance"],
+  },
+  highlightColor: { control: "inline-radio", options: ["yellow", "blue"] },
 };
 
 Object.keys(argTypes).forEach((argType) => {
@@ -58,6 +78,11 @@ const Template = ({
   htmlElement,
   classes,
   attributes,
+  event,
+  eventType,
+  accessDescriptor,
+  highlight,
+  highlightColor,
 }) =>
   Card({
     params: {
@@ -81,6 +106,11 @@ const Template = ({
       htmlElement,
       classes,
       attributes,
+      event,
+      eventType,
+      accessDescriptor,
+      highlight,
+      highlightColor,
     },
   });
 
@@ -288,6 +318,34 @@ WithoutImage.args = {
   body: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel tincidunt velit, a molestie turpis.</p>",
   htmlElement: "article",
   classes: "tna-card--demo",
+};
+
+export const Event = Template.bind({});
+Event.args = {
+  title: "Behind the Scenes Tours",
+  href: "#",
+  headingLevel: 2,
+  headingSize: "l",
+  imageSrc:
+    "https://www.nationalarchives.gov.uk/wp-content/uploads/sites/24/2023/07/tna-building-compress.jpg",
+  imageAlt: "The National Archives office",
+  imageWidth: 400,
+  imageHeight: 243,
+  label: "",
+  body: "<p>We are opening the doors of The National Archives’ repositories to offer you the chance to go behind the scenes.</p>",
+  highlight: "Sold out",
+  highlightColor: "yellow",
+  meta: [
+    { text: "24th September 2023", icon: "calendar" },
+    { text: "From £16", icon: "ticket" },
+    { text: "Online", icon: "location-dot" },
+  ],
+  horizontal: true,
+  event: true,
+  eventType: "Exhibition",
+  accessDescriptor: "Autism-friendly",
+  htmlElement: "article",
+  classes: "tna-card--event tna-card--horizontal-thirds",
 };
 
 const GridTemplate = ({

--- a/src/nationalarchives/components/card/template.njk
+++ b/src/nationalarchives/components/card/template.njk
@@ -10,6 +10,18 @@
 {%- endif -%}
 <{{ htmlElement }} class="tna-card {{ containerClasses | join(' ') }}" data-module="tna-card" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <div class="tna-card__inner">
+  {%- if params.event -%}
+    {%- if params.eventType or params.accessDescriptor -%}
+      <ul class="tna-card__tags">
+        {%- if params.eventType -%}
+          <li class="tna-card__tag tna-card__tag--event-type">{{ params.eventType }}</li>
+        {%- endif -%}
+        {%- if params.accessDescriptor -%}
+          <li class="tna-card__tag tna-card__tag--access">{{ params.accessDescriptor }}</li>
+        {%- endif -%}
+      </ul>
+    {%- endif -%}
+  {%- endif -%}
   {%- if params.supertitle -%}
     <hgroup class="tna-hgroup tna-hgroup--{{ params.headingSize or 'm' }} tna-card__heading">
       <h{{ params.headingLevel }} class="tna-hgroup__title">
@@ -22,13 +34,18 @@
       </h{{ params.headingLevel }}>
     </hgroup>
   {%- else -%}
-    <h{{ params.headingLevel }} class=" tna-heading tna-heading--{{ params.headingSize or 'm' }} tna-card__heading">
+    <h{{ params.headingLevel }} class=" tna-heading tna-heading--{{ params.headingSize or 'm' }} tna-card__heading {% if params.highlight %}tna-card__heading--has-highlight{% endif %}" >
       {%- if params.href -%}
       <a href="{{ params.href }}" class="tna-card__heading-link">{{ params.title }}</a>
       {%- else -%}
       {{ params.title }}
       {%- endif -%}
     </h{{ params.headingLevel }}>
+  {%- endif -%}
+  {%- if params.highlight and params.highlightColor -%}
+    <div class="tna-card__highlight tna-card__highlight--{{ params.highlightColor }}">
+      {{ params.highlight }}
+    </div>
   {%- endif -%}
   {%- if params.imageSrc -%}
     {%- if params.href -%}

--- a/src/nationalarchives/stories/utilities/colour-schemes/colour-schemes.stories.js
+++ b/src/nationalarchives/stories/utilities/colour-schemes/colour-schemes.stories.js
@@ -448,6 +448,30 @@ const Template = ({ theme, accent }) => {
               ...cardDefaultOptions,
               horizontal: true,
               style: "accent",
+              classes: "tna-!--margin-bottom-m",
+            },
+          })}
+        </div>
+        <div class="tna-column tna-column--width-2-3 tna-column--full-medium tna-column--full-small tna-column--full-tiny">
+          ${Card({
+            params: {
+              ...cardDefaultOptions,
+              highlight: "Sold out",
+              highlightColor: "yellow",
+              meta: [
+                { text: "24th September 2023", icon: "calendar" },
+                { text: "From £16", icon: "ticket" },
+                { text: "Online", icon: "location-dot" },
+              ],
+              horizontal: true,
+              event: true,
+              eventType: "Exhibition",
+              accessDescriptor: "Autism-friendly",
+              htmlElement: "article",
+              classes: "tna-card--event tna-card--horizontal-thirds",
+              supertitle: "",
+              actions: [],
+              label: "",
             },
           })}
         </div>


### PR DESCRIPTION
This adds the new styles and stories needed for the event card.

- It adds a new card in the story book list called event
- It adds a new variant for laying out the card at desktop so the image fills one third - 'card--horizontal-thirds'
- Adds overrides to existing card styles for the event card
- Adds 'highlight', 'event type' and 'event descriptor' fields
- Adds dark mode variations for the event card