### PR TITLE
Accessibility Update

### DIFF
--- a/src/nationalarchives/components/tabs/tabs.scss
+++ b/src/nationalarchives/components/tabs/tabs.scss
@@ -126,7 +126,7 @@
     }
 
     .tna-template--clicked &:focus {
-      outline: none;
+      outline-color: transparent;
     }
   }
 


### PR DESCRIPTION
Made a small update to the code: Changed outline: none to outline-color: transparent. It's good to always have this in outlines for inputs and buttons and such, since users with higher contrasts and such could have issues using the tab button selector. This could have an unintentional effect of making special animations and attributes of the button disappear. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8