### PR TITLE
Tweaks and fixes from v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Allowed the arrows to appear on card heading links
+
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Arrow colour for visited heading links with the class `tna-link--no-visited-state`
+- Incorrect padding on the bottom of horizontal cards
+- Removed space between heading and exclamation mark on warning components
+
 ### Security
 
 ## [0.2.1](https://github.com/nationalarchives/tna-frontend/compare/v0.2.0...v0.2.1) - 2024-07-19

--- a/src/nationalarchives/components/card/card.scss
+++ b/src/nationalarchives/components/card/card.scss
@@ -25,16 +25,11 @@
   &--horizontal.tna-background-accent &__inner {
     padding-right: spacing.space(1);
     padding-left: spacing.space(1);
+    padding-bottom: spacing.space(2);
   }
 
   &__heading {
     order: 2;
-  }
-
-  &__heading-link {
-    &::after {
-      display: none !important;
-    }
   }
 
   &--full-click &__heading-link {

--- a/src/nationalarchives/components/card/card.scss
+++ b/src/nationalarchives/components/card/card.scss
@@ -24,8 +24,8 @@
   &--horizontal.tna-background-tint &__inner,
   &--horizontal.tna-background-accent &__inner {
     padding-right: spacing.space(1);
-    padding-left: spacing.space(1);
     padding-bottom: spacing.space(2);
+    padding-left: spacing.space(1);
   }
 
   &__heading {

--- a/src/nationalarchives/components/warning/template.njk
+++ b/src/nationalarchives/components/warning/template.njk
@@ -2,8 +2,7 @@
 {%- set classes = containerClasses | join(' ') -%}
 <div class="tna-warning{% if classes %} {{ classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}{% if value !== '' %}="{{ value }}"{% endif %}{% endfor %}>
   <h{{ params.headingLevel }} class="tna-warning__heading">
-    <span class="tna-visually-hidden">{{ params.heading or 'Important information' }}</span>
-    <span class="tna-warning__heading-icon" aria-hidden="true">!</span>
+    <span class="tna-visually-hidden">{{ params.heading or 'Important information' }}</span><span class="tna-warning__heading-icon" aria-hidden="true">!</span>
   </h{{ params.headingLevel }}>
   <div class="tna-warning__body">
     {{ params.body | safe }}

--- a/src/nationalarchives/utilities/typography/_index.scss
+++ b/src/nationalarchives/utilities/typography/_index.scss
@@ -210,7 +210,7 @@ small {
       @include colour.colour-border("link", 0.125em, solid, right);
     }
 
-    &:visited {
+    &:not(.tna-link--no-visited-state):visited {
       &::after {
         @include colour.colour-border("link-visited");
       }


### PR DESCRIPTION
### Changed

- Allowed the arrows to appear on card heading links

### Fixed

- Arrow colour for visited heading links with the class `tna-link--no-visited-state`
- Incorrect padding on the bottom of horizontal cards
- Removed space between heading and exclamation mark on warning components